### PR TITLE
tika/gotenberg: move x.external to externalTika/Gotenberg

### DIFF
--- a/charts/paperless/templates/secret-app.yaml
+++ b/charts/paperless/templates/secret-app.yaml
@@ -7,40 +7,40 @@ data:
   PAPERLESS_REDIS: {{ (printf "redis://%s-redis:%d" (include "paperless.fullname" .) (int .Values.redis.port)) | b64enc}}
   {{- end }}
   {{- if or (eq .Values.db.type "postgres") (eq .Values.db.type "mariadb") }}
-  {{- if not .Values.db.external.host.existingSecret }}
-  PAPERLESS_DBHOST: {{ .Values.db.external.host.name | b64enc  }}
+  {{- if not .Values.externalDB.host.existingSecret }}
+  PAPERLESS_DBHOST: {{ .Values.externalDB.host.name | b64enc  }}
   {{- end }}
-  {{- if not .Values.db.external.port.existingSecret }}
-  PAPERLESS_DBPORT: {{ toString .Values.db.external.port.value | b64enc  }}
+  {{- if not .Values.externalDB.port.existingSecret }}
+  PAPERLESS_DBPORT: {{ toString .Values.externalDB.port.value | b64enc  }}
   {{- end }}
-  {{- if not .Values.db.external.database.existingSecret }}
-  PAPERLESS_DBNAME: {{ .Values.db.external.database.name | b64enc  }}
+  {{- if not .Values.externalDB.database.existingSecret }}
+  PAPERLESS_DBNAME: {{ .Values.externalDB.database.name | b64enc  }}
   {{- end }}
-  {{- if not .Values.db.external.user.existingSecret }}
-  PAPERLESS_DBUSER: {{ .Values.db.external.user.name | b64enc  }}
+  {{- if not .Values.externalDB.user.existingSecret }}
+  PAPERLESS_DBUSER: {{ .Values.externalDB.user.name | b64enc  }}
   {{- end }}
-  {{- if not .Values.db.external.password.existingSecret }}
-  PAPERLESS_DBPASS: {{ .Values.db.external.password.value | b64enc  }}
+  {{- if not .Values.externalDB.password.existingSecret }}
+  PAPERLESS_DBPASS: {{ .Values.externalDB.password.value | b64enc  }}
   {{- end }}
-  {{- if .Values.db.external.sslMode }}
-  PAPERLESS_DBSSLMODE: {{ .Values.db.external.sslMode | b64enc  }}
+  {{- if .Values.externalDB.sslMode }}
+  PAPERLESS_DBSSLMODE: {{ .Values.externalDB.sslMode | b64enc  }}
   {{- end }}
-  {{- if or .Values.db.external.sslRootCert.certificate .Values.db.external.sslRootCert.existingSecret }}
+  {{- if or .Values.externalDB.sslRootCert.certificate .Values.externalDB.sslRootCert.existingSecret }}
   PAPERLESS_DBSSLROOTCERT: {{ printf "/etc/ssl/paperless-root-cert/cert" | b64enc }}
   {{- end }}
-  {{- if and (not .Values.db.external.sslRootCert.existingSecret) .Values.db.external.sslRootCert.certificate }}
-  _root-cert: {{ .Values.db.external.sslRootCert.certificate | b64enc  }}
+  {{- if and (not .Values.externalDB.sslRootCert.existingSecret) .Values.externalDB.sslRootCert.certificate }}
+  _root-cert: {{ .Values.externalDB.sslRootCert.certificate | b64enc  }}
   {{- end }}
-  {{- if or .Values.db.external.sslClientCert.certificate .Values.db.external.sslClientCert.existingSecret }}
+  {{- if or .Values.externalDB.sslClientCert.certificate .Values.externalDB.sslClientCert.existingSecret }}
   PAPERLESS_DBSSLCERT: {{ printf "/etc/ssl/paperless-client-cert/cert" | b64enc }}
   {{- end }}
-  {{- if and (not .Values.db.external.sslClientCert.existingSecret) .Values.db.external.sslClientCert.certificate }}
-  _client-cert: {{ .Values.db.external.sslClientCert.certificate | b64enc  }}
+  {{- if and (not .Values.externalDB.sslClientCert.existingSecret) .Values.externalDB.sslClientCert.certificate }}
+  _client-cert: {{ .Values.externalDB.sslClientCert.certificate | b64enc  }}
   {{- end }}
-  {{- if or .Values.db.external.sslClientKey.key .Values.db.external.sslClientKey.existingSecret }}
+  {{- if or .Values.externalDB.sslClientKey.key .Values.externalDB.sslClientKey.existingSecret }}
   PAPERLESS_DBSSLKEY: {{ printf "/etc/ssl/paperless-client-key/key" | b64enc }}
   {{- end }}
-  {{- if and (not .Values.db.external.sslClientKey.existingSecret) .Values.db.external.sslClientKey.key }}
-  _client-key: {{ .Values.db.external.sslClientKey.key | b64enc  }}
+  {{- if and (not .Values.externalDB.sslClientKey.existingSecret) .Values.externalDB.sslClientKey.key }}
+  _client-key: {{ .Values.externalDB.sslClientKey.key | b64enc  }}
   {{- end }}
   {{- end }}

--- a/charts/paperless/templates/statefulset.yaml
+++ b/charts/paperless/templates/statefulset.yaml
@@ -59,35 +59,35 @@ spec:
                   {{- toYaml .Values.externalRedis.existingSecret | nindent 18 }}
           {{- end }}
           {{- if or (eq .Values.db.type "postgres") (eq .Values.db.type "mariadb") }}
-          {{- if .Values.db.external.host.existingSecret }}
+          {{- if .Values.externalDB.host.existingSecret }}
             - name: PAPERLESS_DBHOST
               valueFrom:
                 secretKeyRef:
-                  {{- toYaml .Values.db.external.host.existingSecret | nindent 18 }}
+                  {{- toYaml .Values.externalDB.host.existingSecret | nindent 18 }}
           {{- end }}
-          {{- if .Values.db.external.port.existingSecret }}
+          {{- if .Values.externalDB.port.existingSecret }}
             - name: PAPERLESS_DBPORT
               valueFrom:
                 secretKeyRef:
-                  {{- toYaml .Values.db.external.port.existingSecret | nindent 18 }}
+                  {{- toYaml .Values.externalDB.port.existingSecret | nindent 18 }}
           {{- end }}
-          {{- if .Values.db.external.database.existingSecret }}
+          {{- if .Values.externalDB.database.existingSecret }}
             - name: PAPERLESS_DBNAME
               valueFrom:
                 secretKeyRef:
-                  {{- toYaml .Values.db.external.database.existingSecret | nindent 18 }}
+                  {{- toYaml .Values.externalDB.database.existingSecret | nindent 18 }}
           {{- end }}
-          {{- if .Values.db.external.user.existingSecret }}
+          {{- if .Values.externalDB.user.existingSecret }}
             - name: PAPERLESS_DBUSER
               valueFrom:
                 secretKeyRef:
-                  {{- toYaml .Values.db.external.user.existingSecret | nindent 18 }}
+                  {{- toYaml .Values.externalDB.user.existingSecret | nindent 18 }}
           {{- end }}
-          {{- if .Values.db.external.password.existingSecret }}
+          {{- if .Values.externalDB.password.existingSecret }}
             - name: PAPERLESS_DBPASS
               valueFrom:
                 secretKeyRef:
-                  {{- toYaml .Values.db.external.password.existingSecret | nindent 18 }}
+                  {{- toYaml .Values.externalDB.password.existingSecret | nindent 18 }}
           {{- end }}
           {{- end }}
           {{- if .Values.paperless.admin.enabled }}
@@ -177,17 +177,17 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-          {{- if .Values.db.external.sslRootCert.existingSecret }}
+          {{- if .Values.externalDB.sslRootCert.existingSecret }}
             - name: sslRootCert
               mountPath: /etc/ssl/paperless-root-cert/
               readOnly: true
           {{- end }}
-          {{- if .Values.db.external.sslClientCert.existingSecret }}
+          {{- if .Values.externalDB.sslClientCert.existingSecret }}
             - name: sslClientCert
               mountPath: /etc/ssl/paperless-client-cert/
               readOnly: true
           {{- end }}
-          {{- if .Values.db.external.sslClientKey.existingSecret }}
+          {{- if .Values.externalDB.sslClientKey.existingSecret }}
             - name: sslClientKey
               mountPath: /etc/ssl/paperless-client-key/
               readOnly: true
@@ -212,14 +212,14 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
-      {{- if .Values.db.external.sslRootCert.existingSecret }}
+      {{- if .Values.externalDB.sslRootCert.existingSecret }}
         - name: sslRootCert
           secret:
-            secretName: {{ .Values.db.external.sslRootCert.existingSecret.name }}
+            secretName: {{ .Values.externalDB.sslRootCert.existingSecret.name }}
             items:
-              - key: {{ .Values.db.external.sslRootCert.existingSecret.key }}
+              - key: {{ .Values.externalDB.sslRootCert.existingSecret.key }}
                 path: cert
-      {{- else if .Values.db.external.sslRootCert.certificate }}
+      {{- else if .Values.externalDB.sslRootCert.certificate }}
         - name: sslRootCert
           secret:
             secretName: {{ include "paperless.fullname" . }}-app
@@ -227,14 +227,14 @@ spec:
               - key: _root-cert
                 path: cert
       {{- end }}
-      {{- if .Values.db.external.sslClientCert.existingSecret }}
+      {{- if .Values.externalDB.sslClientCert.existingSecret }}
         - name: sslClientCert
           secret:
-            secretName: {{ .Values.db.external.sslClientCert.existingSecret.name }}
+            secretName: {{ .Values.externalDB.sslClientCert.existingSecret.name }}
             items:
-              - key: {{ .Values.db.external.sslClientCert.existingSecret.key }}
+              - key: {{ .Values.externalDB.sslClientCert.existingSecret.key }}
                 path: cert
-      {{- else if .Values.db.external.sslClientCert.certificate }}
+      {{- else if .Values.externalDB.sslClientCert.certificate }}
         - name: sslClientCert
           secret:
             secretName: {{ include "paperless.fullname" . }}-app
@@ -242,14 +242,14 @@ spec:
               - key: _client-cert
                 path: cert
       {{- end }}
-      {{- if .Values.db.external.sslClientKey.existingSecret }}
+      {{- if .Values.externalDB.sslClientKey.existingSecret }}
         - name: sslClientKey
           secret:
-            secretName: {{ .Values.db.external.sslClientKey.existingSecret.name }}
+            secretName: {{ .Values.externalDB.sslClientKey.existingSecret.name }}
             items:
-              - key: {{ .Values.db.external.sslClientKey.existingSecret.key }}
+              - key: {{ .Values.externalDB.sslClientKey.existingSecret.key }}
                 path: key
-      {{- else if .Values.db.external.sslClientKey.key }}
+      {{- else if .Values.externalDB.sslClientKey.key }}
         - name: sslClientKey
           secret:
             secretName: {{ include "paperless.fullname" . }}-app

--- a/charts/paperless/values.yaml
+++ b/charts/paperless/values.yaml
@@ -261,54 +261,54 @@ gotenberg:
 db:
   # -- The type of DB to use (`sqlite/mariadb/postgres`). If you want to use an external MariaDB/Postgres instance, specify its values in `db.external``
   type: sqlite
-  external:
-    host:
-      # -- Remote DB hostname
-      name: ""
-      existingSecret: {}
-      #  name: ""
-      #  key: ""
-    port:
-      # -- Remote DB port
-      value: 5432
-      existingSecret: {}
-      #  name: ""
-      #  key: ""
-    database:
-      # -- Remote DB database
-      name: ""
-      existingSecret: {}
-      #  name: ""
-      #  key: ""
-    user:
-      # -- Remote DB username
-      name: ""
-      existingSecret: {}
-      #  name: ""
-      #  key: ""
-    password:
-      # -- Remote DB password
-      value: ""
-      existingSecret: {}
-      #  name: ""
-      #  key: ""
-    # -- Remote DB SSL/TLS connection mode. See https://docs.paperless-ngx.com/configuration/#PAPERLESS_DBSSLMODE
-    sslMode: ""
-    sslRootCert:
-      # -- Remote DB server TLS certificate
-      certificate: ""
-      existingSecret: {}
-      #  name: ""
-      #  key: ""
-    sslClientCert:
-      # -- Remote DB client TLS certificate
-      certificate: ""
-      existingSecret: {}
-      #  name: ""
-      #  key: ""
-    sslClientKey:
-      # -- Remote DB client TLS key
-      key: ""
-      existingSecret: {}
-      #  name: ""
-      #  key: ""
+externalDB:
+  host:
+    # -- Remote DB hostname
+    name: ""
+    existingSecret: {}
+    #  name: ""
+    #  key: ""
+  port:
+    # -- Remote DB port
+    value: 5432
+    existingSecret: {}
+    #  name: ""
+    #  key: ""
+  database:
+    # -- Remote DB database
+    name: ""
+    existingSecret: {}
+    #  name: ""
+    #  key: ""
+  user:
+    # -- Remote DB username
+    name: ""
+    existingSecret: {}
+    #  name: ""
+    #  key: ""
+  password:
+    # -- Remote DB password
+    value: ""
+    existingSecret: {}
+    #  name: ""
+    #  key: ""
+  # -- Remote DB SSL/TLS connection mode. See https://docs.paperless-ngx.com/configuration/#PAPERLESS_DBSSLMODE
+  sslMode: ""
+  sslRootCert:
+    # -- Remote DB server TLS certificate
+    certificate: ""
+    existingSecret: {}
+    #  name: ""
+    #  key: ""
+  sslClientCert:
+    # -- Remote DB client TLS certificate
+    certificate: ""
+    existingSecret: {}
+    #  name: ""
+    #  key: ""
+  sslClientKey:
+    # -- Remote DB client TLS key
+    key: ""
+    existingSecret: {}
+    #  name: ""
+    #  key: ""


### PR DESCRIPTION
The Gotenberg chart, like most charts expects to be used as an optional dependency via a simple ".enabled" key. This chart used to nest this key as "gotenberg.bundled.enabled", which caused errors with the charts values schema.

Fix this by splitting out Gotenberg/Tika dependencies into `externalGotenberg`/`externalTika` for external inclusion and `gotenberg/tika` for the bundled chart